### PR TITLE
docs: use issue-triage example with sentinel and REPO var

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,17 @@ import { loop } from "@0xtiby/looper";
 
 const result = await loop({
   cli: "claude",
-  prompt: "Fix the failing tests. Emit :::DONE::: when finished.",
+  prompt: `
+    1. Run: gh issue list --repo {{REPO}} --state open --json
+    2. Pick the next unblocked issue labeled "ready".
+    3. Implement it: write code, tests, commit, open a PR,
+    4. Exit.
+    When no unblocked issues remain, emit :::DONE:::
+  `.trim(),
+  cwd: process.cwd(),
+  maxIterations: 20,
   sentinel: ":::DONE:::",
-  maxIterations: 5,
+  vars: { REPO: "0xtiby/looper" },
 });
 
 console.log(result.stopReason); // "sentinel" | "max_iterations" | "error" | "aborted"


### PR DESCRIPTION
## Summary
Replaces the library-usage Basic example with a more illustrative issue-triage loop:
- Shows how to pass a multi-line prompt
- Uses `{{REPO}}` to demonstrate template variables
- Sets an explicit `sentinel` (`:::DONE:::`) to match the prompt instruction
- Sets `vars: { REPO: "0xtiby/looper" }` so the placeholder is actually substituted

Supersedes the same two commits that missed the merge window of #13.

## Test plan
- [ ] Preview the README — confirm the snippet renders as intended.