### PR TITLE
feat: add pi CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 A standalone engine for looping an AI coding CLI against a prompt until it signals it's done:
 
-1. You give Looper a prompt and pick a CLI (`claude`, `codex`, or `opencode`).
+1. You give Looper a prompt and pick a CLI (`claude`, `codex`, `opencode`, or `pi`).
 2. Looper spawns the CLI, streams its output, and watches for a sentinel string.
 3. It re-spawns from scratch each iteration until the sentinel fires, `maxIterations` is reached, or the CLI exits non-zero.
 
@@ -32,6 +32,7 @@ Under the hood, Looper drives the CLIs via [`@0xtiby/spawner`](https://github.co
   - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`claude`)
   - [Codex CLI](https://github.com/openai/codex) (`codex`)
   - [OpenCode](https://github.com/sst/opencode) (`opencode`)
+  - [pi](https://github.com/0xtiby/pi) (`pi`)
 
 ## Quick start
 
@@ -82,7 +83,7 @@ cat plan.md | looper run --prompt-stdin
 | --- | --- |
 | `-p, --prompt <value>` | Inline string OR path to an existing file (auto-detected). |
 | `--prompt-stdin` | Read the prompt from stdin. |
-| `--cli <name>` | One of `claude`, `codex`, `opencode`. Overrides config. |
+| `--cli <name>` | One of `claude`, `codex`, `opencode`, `pi`. Overrides config. |
 | `--model <name>` | Model override (e.g. `opus`, `sonnet`). |
 | `--max-iterations <n>` | Cap the number of iterations. |
 | `--sentinel <string>` | String the AI must emit to stop the loop. |
@@ -141,7 +142,7 @@ const result = await loop({
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `cli` | `"claude" \| "codex" \| "opencode"` | — | **Required.** The AI CLI to spawn. |
+| `cli` | `"claude" \| "codex" \| "opencode" \| "pi"` | — | **Required.** The AI CLI to spawn. |
 | `prompt` | `string` | — | **Required.** Prompt string passed to the CLI. |
 | `cwd` | `string` | `process.cwd()` | Working directory for the spawned CLI. |
 | `model` | `string` | — | Model override (e.g. `opus`, `sonnet`). |

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "loop",
     "orchestration",
     "claude",
-    "codex"
+    "codex",
+    "pi"
   ],
   "author": "0xtiby",
   "license": "MIT",
@@ -58,7 +59,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@0xtiby/spawner": "^1.2.1",
+    "@0xtiby/spawner": "^1.3.0",
     "commander": "^14.0.3",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@0xtiby/spawner':
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: ^1.3.0
+        version: 1.3.0
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -42,8 +42,8 @@ importers:
 
 packages:
 
-  '@0xtiby/spawner@1.2.1':
-    resolution: {integrity: sha512-Ro94MjbBAEt6NrBEoqsEyQupGS/jjxQXwycjrJMwLyuF4wfafN3I0x2gMtaISvayEfyUNqToZxmp76nq+J2hiA==}
+  '@0xtiby/spawner@1.3.0':
+    resolution: {integrity: sha512-1mCc1oYs3J7xLvx/Iiy8ZGsqPou+d/q6FLcdQsk58Bpl8TJ/MSM9icVP1JV9fB7GPLbxhJjgxdcCQbYFC62j7g==}
 
   '@actions/core@3.0.0':
     resolution: {integrity: sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==}
@@ -2264,7 +2264,7 @@ packages:
 
 snapshots:
 
-  '@0xtiby/spawner@1.2.1': {}
+  '@0xtiby/spawner@1.3.0': {}
 
   '@actions/core@3.0.0':
     dependencies:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ import {
 } from "./session.js";
 import { loadPrompt } from "./template.js";
 
-const SUPPORTED_CLIS: CliName[] = ["claude", "codex", "opencode"];
+const SUPPORTED_CLIS: CliName[] = ["claude", "codex", "opencode", "pi"];
 
 interface RunCommandOptions {
   prompt?: string;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import type { CliName } from "@0xtiby/spawner";
 import { Command, InvalidArgumentError, Option } from "commander";
 import {
   applyOverrides,
+  CliNameSchema,
   loadConfig,
   resolveConfig,
   writeDefaultConfig,
@@ -22,7 +23,7 @@ import {
 } from "./session.js";
 import { loadPrompt } from "./template.js";
 
-const SUPPORTED_CLIS: CliName[] = ["claude", "codex", "opencode", "pi"];
+const SUPPORTED_CLIS: CliName[] = [...CliNameSchema.options];
 
 interface RunCommandOptions {
   prompt?: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import type { CliName } from "@0xtiby/spawner";
 import { z } from "zod";
 
-export const CliNameSchema = z.enum(["claude", "codex", "opencode"]);
+export const CliNameSchema = z.enum(["claude", "codex", "opencode", "pi"]);
 
 export const ConfigSchema = z.object({
   cli: CliNameSchema.optional(),


### PR DESCRIPTION
Bump @0xtiby/spawner to ^1.3.0 which adds \pi\ as a CliName option.

**Changes:**
- Bump \@0xtiby/spawner\: \^1.2.1\ → \^1.3.0\
- Add \pi\ to \CliNameSchema\ in src/config.ts
- Add \pi\ to \SUPPORTED_CLIS\ in src/cli.ts
- Update README.md with pi references in prerequisites, quick start, CLI flags, and LoopOptions docs
- Add \pi\ keyword to package.json
- Remove stale .worktrees/feat-pi-extension that caused biome nested-config errors