### PR TITLE
fix(pi-extension): pass string labels to ui.select

### DIFF
--- a/pi-extension/index.ts
+++ b/pi-extension/index.ts
@@ -223,6 +223,21 @@ async function runLooper(
   };
 }
 
+async function selectLabeled<T extends string>(
+  ui: {
+    select: (title: string, opts: string[]) => Promise<string | undefined>;
+  },
+  title: string,
+  options: ReadonlyArray<readonly [T, string]>,
+): Promise<T | undefined> {
+  const pick = await ui.select(
+    title,
+    options.map(([, label]) => label),
+  );
+  if (!pick) return undefined;
+  return options.find(([, label]) => label === pick)?.[0];
+}
+
 type PromptChoice = { prompt: string; promptFile?: string };
 
 async function pickPrompt(ctx: {
@@ -232,16 +247,17 @@ async function pickPrompt(ctx: {
   const promptFiles = await listPromptFiles(ctx.cwd);
 
   if (promptFiles.length > 0) {
+    const NEW_PROMPT = "__new__";
     const NEW_PROMPT_LABEL = "✎  Write new prompt...";
-    const fileLabels = promptFiles.map((p) => p.replace(`${ctx.cwd}/`, ""));
-    const labels = [...fileLabels, NEW_PROMPT_LABEL];
-    const choice = await ctx.ui.select("Choose prompt:", labels);
-    if (!choice) return null;
-    const idx = fileLabels.indexOf(choice);
-    if (idx >= 0) {
-      const promptFile = promptFiles[idx];
-      const prompt = await readFile(promptFile, "utf8");
-      return { prompt, promptFile };
+    const options = [
+      ...promptFiles.map((p) => [p, p.replace(`${ctx.cwd}/`, "")] as const),
+      [NEW_PROMPT, NEW_PROMPT_LABEL] as const,
+    ];
+    const chosen = await selectLabeled(ctx.ui, "Choose prompt:", options);
+    if (!chosen) return null;
+    if (chosen !== NEW_PROMPT) {
+      const prompt = await readFile(chosen, "utf8");
+      return { prompt, promptFile: chosen };
     }
   }
 
@@ -356,16 +372,11 @@ export default function (pi: ExtensionAPI) {
 
       let chosenMux: Multiplexer = avail.preferred;
       if (avail.zellij && avail.tmux) {
-        const muxLabels: Record<Multiplexer, string> = {
-          zellij: "zellij (pane in current session)",
-          tmux: "tmux (new detached session)",
-        };
-        const pick = await ctx.ui.select("Multiplexer:", [
-          muxLabels.zellij,
-          muxLabels.tmux,
-        ]);
-        if (pick === muxLabels.zellij) chosenMux = "zellij";
-        else if (pick === muxLabels.tmux) chosenMux = "tmux";
+        chosenMux =
+          (await selectLabeled(ctx.ui, "Multiplexer:", [
+            ["zellij", "zellij (pane in current session)"],
+            ["tmux", "tmux (new detached session)"],
+          ] as const)) ?? avail.preferred;
       }
 
       if (chosenMux === "zellij" && !isInZellij()) {
@@ -401,21 +412,12 @@ export default function (pi: ExtensionAPI) {
       let floating = false;
 
       if (chosenMux === "zellij") {
-        const dirLabels: Record<Direction, string> = {
-          right: "right →",
-          down: "down ↓",
-          left: "left ←",
-          up: "up ↑",
-        };
-        const dirPick = await ctx.ui.select("Pane direction:", [
-          dirLabels.right,
-          dirLabels.down,
-          dirLabels.left,
-          dirLabels.up,
-        ]);
-        direction = (Object.keys(dirLabels) as Direction[]).find(
-          (k) => dirLabels[k] === dirPick,
-        );
+        direction = await selectLabeled(ctx.ui, "Pane direction:", [
+          ["right", "right →"],
+          ["down", "down ↓"],
+          ["left", "left ←"],
+          ["up", "up ↑"],
+        ] as const);
         floating =
           (await ctx.ui.confirm(
             "Floating pane?",

--- a/pi-extension/index.ts
+++ b/pi-extension/index.ts
@@ -232,17 +232,14 @@ async function pickPrompt(ctx: {
   const promptFiles = await listPromptFiles(ctx.cwd);
 
   if (promptFiles.length > 0) {
-    const choices = [
-      ...promptFiles.map((p) => ({
-        value: `file:${p}`,
-        label: p.replace(`${ctx.cwd}/`, ""),
-      })),
-      { value: "__new__", label: "✎  Write new prompt..." },
-    ];
-    const choice = await ctx.ui.select("Choose prompt:", choices);
+    const NEW_PROMPT_LABEL = "✎  Write new prompt...";
+    const fileLabels = promptFiles.map((p) => p.replace(`${ctx.cwd}/`, ""));
+    const labels = [...fileLabels, NEW_PROMPT_LABEL];
+    const choice = await ctx.ui.select("Choose prompt:", labels);
     if (!choice) return null;
-    if (choice.startsWith("file:")) {
-      const promptFile = choice.slice(5);
+    const idx = fileLabels.indexOf(choice);
+    if (idx >= 0) {
+      const promptFile = promptFiles[idx];
       const prompt = await readFile(promptFile, "utf8");
       return { prompt, promptFile };
     }
@@ -359,11 +356,16 @@ export default function (pi: ExtensionAPI) {
 
       let chosenMux: Multiplexer = avail.preferred;
       if (avail.zellij && avail.tmux) {
+        const muxLabels: Record<Multiplexer, string> = {
+          zellij: "zellij (pane in current session)",
+          tmux: "tmux (new detached session)",
+        };
         const pick = await ctx.ui.select("Multiplexer:", [
-          { value: "zellij", label: "zellij (pane in current session)" },
-          { value: "tmux", label: "tmux (new detached session)" },
+          muxLabels.zellij,
+          muxLabels.tmux,
         ]);
-        if (pick) chosenMux = pick as Multiplexer;
+        if (pick === muxLabels.zellij) chosenMux = "zellij";
+        else if (pick === muxLabels.tmux) chosenMux = "tmux";
       }
 
       if (chosenMux === "zellij" && !isInZellij()) {
@@ -399,13 +401,21 @@ export default function (pi: ExtensionAPI) {
       let floating = false;
 
       if (chosenMux === "zellij") {
+        const dirLabels: Record<Direction, string> = {
+          right: "right →",
+          down: "down ↓",
+          left: "left ←",
+          up: "up ↑",
+        };
         const dirPick = await ctx.ui.select("Pane direction:", [
-          { value: "right", label: "right →" },
-          { value: "down", label: "down ↓" },
-          { value: "left", label: "left ←" },
-          { value: "up", label: "up ↑" },
+          dirLabels.right,
+          dirLabels.down,
+          dirLabels.left,
+          dirLabels.up,
         ]);
-        direction = dirPick as Direction | undefined;
+        direction = (Object.keys(dirLabels) as Direction[]).find(
+          (k) => dirLabels[k] === dirPick,
+        );
         floating =
           (await ctx.ui.confirm(
             "Floating pane?",


### PR DESCRIPTION
Closes #17

`pi`'s `ExtensionAPI.ui.select` signature is `select(title, options: string[])` — it expects a flat array of strings. The pi-extension was passing `{value, label}` objects, which rendered via implicit `toString()` as `[object Object]` in the picker.

Fixed three call sites in `pi-extension/index.ts`:
- prompt picker (the one in the screenshot from #17)
- multiplexer picker
- pane direction picker

Each now passes a `string[]` of labels and maps the returned label back to the typed value.