### PR TITLE
Update spawner for Pi text streaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,13 +61,13 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@0xtiby/spawner": "^1.3.0",
+    "@0xtiby/spawner": "^1.3.1",
     "commander": "^14.0.3",
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.70.2",
     "@mariozechner/pi-ai": "^0.70.2",
+    "@mariozechner/pi-coding-agent": "^0.70.2",
     "@mariozechner/pi-tui": "^0.70.2",
     "typebox": "^1.1.34"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@0xtiby/spawner':
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.3.1
+        version: 1.3.1
       '@mariozechner/pi-ai':
         specifier: ^0.70.2
         version: 0.70.2(ws@8.20.0)(zod@4.3.6)
@@ -54,8 +54,8 @@ importers:
 
 packages:
 
-  '@0xtiby/spawner@1.3.0':
-    resolution: {integrity: sha512-1mCc1oYs3J7xLvx/Iiy8ZGsqPou+d/q6FLcdQsk58Bpl8TJ/MSM9icVP1JV9fB7GPLbxhJjgxdcCQbYFC62j7g==}
+  '@0xtiby/spawner@1.3.1':
+    resolution: {integrity: sha512-3xfpgujCS319dX1+4rA3cCQIETG9uqGxD+pCD9Yv6nGVUAtqOD34de0dbr1kiv1gEZUeMTSR625toe/7nCGkmA==}
 
   '@actions/core@3.0.0':
     resolution: {integrity: sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==}
@@ -3090,7 +3090,7 @@ packages:
 
 snapshots:
 
-  '@0xtiby/spawner@1.3.0': {}
+  '@0xtiby/spawner@1.3.1': {}
 
   '@actions/core@3.0.0':
     dependencies:


### PR DESCRIPTION
## Summary
- update @0xtiby/spawner to 1.3.1 for Pi text_delta streaming support
- refresh pnpm lockfile

## Verification
- ./scripts/run_silent "test" pnpm test
- ./scripts/run_silent "typecheck" pnpm typecheck
- ./scripts/run_silent "lint" pnpm lint
- ./scripts/run_silent "build" pnpm build
- manual looper run with --cli pi recorded streamed assistant text in .looper/sessions/*.log

Closes #20