### PR TITLE
Preserve streamed text deltas in transcripts

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,16 +7,27 @@ import type {
 import { describe, expect, it, vi } from "vitest";
 import { loop, type Spawner } from "./index.js";
 
-async function* textEvents(chunks: string[]): AsyncGenerator<CliEvent> {
-  for (const content of chunks) {
-    yield { type: "text", timestamp: 0, content, raw: content };
+async function* cliEvents(events: CliEvent[]): AsyncGenerator<CliEvent> {
+  for (const event of events) {
+    yield event;
   }
 }
 
+function textEvent(content: string): CliEvent {
+  return { type: "text", timestamp: 0, content, raw: content };
+}
+
 function fakeProcess(result: CliResult, chunks: string[] = []): CliProcess {
+  return fakeProcessWithEvents(result, chunks.map(textEvent));
+}
+
+function fakeProcessWithEvents(
+  result: CliResult,
+  events: CliEvent[],
+): CliProcess {
   return {
     pid: 1,
-    events: textEvents(chunks),
+    events: cliEvents(events),
     interrupt: async () => result,
     done: Promise.resolve(result),
   };
@@ -95,9 +106,9 @@ describe("loop", () => {
     expect(result.iterations[0]?.sentinelDetected).toBe(true);
   });
 
-  it("invokes onOutput with each text chunk, appending a newline when missing", async () => {
+  it("invokes onOutput with each text chunk exactly as received", async () => {
     const spawn: Spawner = () =>
-      fakeProcess(okResult(), ["hello", "world\n", "!"]);
+      fakeProcess(okResult(), ["hel", "lo\n", "world"]);
     const received: string[] = [];
 
     await loop(
@@ -111,18 +122,53 @@ describe("loop", () => {
       { spawn },
     );
 
-    expect(received).toEqual(["hello\n", "world\n", "!\n"]);
+    expect(received).toEqual(["hel", "lo\n", "world"]);
   });
 
-  it("captures per-iteration stdout with one line per event", async () => {
-    const spawn: Spawner = () => fakeProcess(okResult(), ["alpha", "beta"]);
+  it("captures streamed text without adding newlines between chunks", async () => {
+    const spawn: Spawner = () =>
+      fakeProcess(okResult(), ["/home", "/t", "iby"]);
+
+    const result = await loop(
+      { cli: "pi", prompt: "x", cwd: "/w", maxIterations: 1 },
+      { spawn },
+    );
+
+    expect(result.iterations[0]?.stdout).toBe("/home/tiby");
+  });
+
+  it("detects sentinel split across streamed text chunks", async () => {
+    const spawn: Spawner = () =>
+      fakeProcess(okResult(), ["work ", ":::LO", "OPER_DONE", ":::"]);
+
+    const result = await loop(
+      { cli: "pi", prompt: "x", cwd: "/w", maxIterations: 2 },
+      { spawn },
+    );
+
+    expect(result.stopReason).toBe("sentinel");
+  });
+
+  it("keeps error events line-oriented in stdout", async () => {
+    const spawn: Spawner = () =>
+      fakeProcessWithEvents(okResult(), [
+        { type: "error", timestamp: 0, content: "boom", raw: "boom" },
+        {
+          type: "tool_result",
+          timestamp: 0,
+          toolResult: { name: "bash", error: "failed" },
+          raw: "failed",
+        },
+      ]);
 
     const result = await loop(
       { cli: "claude", prompt: "x", cwd: "/w", maxIterations: 1 },
       { spawn },
     );
 
-    expect(result.iterations[0]?.stdout).toBe("alpha\nbeta\n");
+    expect(result.iterations[0]?.stdout).toBe(
+      "[error] boom\n[tool bash error] failed\n",
+    );
   });
 
   it("surfaces durationMs and token usage from the spawner", async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -171,6 +171,21 @@ describe("loop", () => {
     );
   });
 
+  it("separates line-oriented events from preceding raw text chunks", async () => {
+    const spawn: Spawner = () =>
+      fakeProcessWithEvents(okResult(), [
+        textEvent("partial"),
+        { type: "error", timestamp: 0, content: "boom", raw: "boom" },
+      ]);
+
+    const result = await loop(
+      { cli: "pi", prompt: "x", cwd: "/w", maxIterations: 1 },
+      { spawn },
+    );
+
+    expect(result.iterations[0]?.stdout).toBe("partial\n[error] boom\n");
+  });
+
   it("surfaces durationMs and token usage from the spawner", async () => {
     const spawn: Spawner = () =>
       fakeProcess({

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,23 +7,35 @@ import type {
 import { spawn as spawnCli } from "@0xtiby/spawner";
 import { substitute } from "./template.js";
 
-function transcriptChunkForEvent(event: CliEvent): string | null {
+type TranscriptChunk =
+  | { type: "raw"; text: string }
+  | { type: "line"; text: string };
+
+function transcriptChunkForEvent(event: CliEvent): TranscriptChunk | null {
   if (event.type === "text" && typeof event.content === "string") {
-    return event.content;
+    return { type: "raw", text: event.content };
   }
   if (event.type === "error" && typeof event.content === "string") {
-    return lineChunk(`[error] ${event.content}`);
+    return { type: "line", text: `[error] ${event.content}` };
   }
   if (event.type === "tool_result" && event.toolResult?.error) {
-    return lineChunk(
-      `[tool ${event.toolResult.name} error] ${event.toolResult.error}`,
-    );
+    return {
+      type: "line",
+      text: `[tool ${event.toolResult.name} error] ${event.toolResult.error}`,
+    };
   }
   return null;
 }
 
-function lineChunk(text: string): string {
-  return text.endsWith("\n") ? text : `${text}\n`;
+function appendTranscriptChunk(stdout: string, chunk: TranscriptChunk): string {
+  if (chunk.type === "raw") return chunk.text;
+  return lineChunk(stdout, chunk.text);
+}
+
+function lineChunk(stdout: string, text: string): string {
+  const prefix = stdout.length > 0 && !stdout.endsWith("\n") ? "\n" : "";
+  const suffix = text.endsWith("\n") ? "" : "\n";
+  return `${prefix}${text}${suffix}`;
 }
 
 export type StopReason = "sentinel" | "max_iterations" | "error" | "aborted";
@@ -162,8 +174,9 @@ async function runIteration(
     let stdout = "";
     let sentinelDetected = false;
     for await (const event of proc.events) {
-      const chunk = transcriptChunkForEvent(event);
-      if (chunk === null) continue;
+      const transcriptChunk = transcriptChunkForEvent(event);
+      if (transcriptChunk === null) continue;
+      const chunk = appendTranscriptChunk(stdout, transcriptChunk);
       stdout += chunk;
       ctx.onOutput?.(chunk);
       if (!sentinelDetected && stdout.includes(ctx.sentinel)) {
@@ -179,7 +192,7 @@ async function runIteration(
         }
       : null;
     if (error && !stdout.includes(error.message)) {
-      const line = lineChunk(`[${error.code}] ${error.message}`);
+      const line = lineChunk(stdout, `[${error.code}] ${error.message}`);
       stdout += line;
       ctx.onOutput?.(line);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,17 +7,23 @@ import type {
 import { spawn as spawnCli } from "@0xtiby/spawner";
 import { substitute } from "./template.js";
 
-function textForEvent(event: CliEvent): string | null {
+function transcriptChunkForEvent(event: CliEvent): string | null {
   if (event.type === "text" && typeof event.content === "string") {
     return event.content;
   }
   if (event.type === "error" && typeof event.content === "string") {
-    return `[error] ${event.content}`;
+    return lineChunk(`[error] ${event.content}`);
   }
   if (event.type === "tool_result" && event.toolResult?.error) {
-    return `[tool ${event.toolResult.name} error] ${event.toolResult.error}`;
+    return lineChunk(
+      `[tool ${event.toolResult.name} error] ${event.toolResult.error}`,
+    );
   }
   return null;
+}
+
+function lineChunk(text: string): string {
+  return text.endsWith("\n") ? text : `${text}\n`;
 }
 
 export type StopReason = "sentinel" | "max_iterations" | "error" | "aborted";
@@ -156,9 +162,8 @@ async function runIteration(
     let stdout = "";
     let sentinelDetected = false;
     for await (const event of proc.events) {
-      const text = textForEvent(event);
-      if (text === null) continue;
-      const chunk = text.endsWith("\n") ? text : `${text}\n`;
+      const chunk = transcriptChunkForEvent(event);
+      if (chunk === null) continue;
       stdout += chunk;
       ctx.onOutput?.(chunk);
       if (!sentinelDetected && stdout.includes(ctx.sentinel)) {
@@ -174,7 +179,7 @@ async function runIteration(
         }
       : null;
     if (error && !stdout.includes(error.message)) {
-      const line = `[${error.code}] ${error.message}\n`;
+      const line = lineChunk(`[${error.code}] ${error.message}`);
       stdout += line;
       ctx.onOutput?.(line);
     }


### PR DESCRIPTION
## Summary
- append text events exactly as received instead of adding synthetic newlines
- keep error and tool-error transcript entries line-oriented
- add regression coverage for streamed chunks and split sentinel detection

Fixes #22

## Tests
- ./scripts/run_silent "typecheck" pnpm typecheck
- ./scripts/run_silent "lint" pnpm lint
- ./scripts/run_silent "test" pnpm test